### PR TITLE
Update the rockspec so that the Luarocks install works.

### DIFF
--- a/mjolnir.bg.grid-0.1-3.rockspec
+++ b/mjolnir.bg.grid-0.1-3.rockspec
@@ -1,5 +1,5 @@
 package = "mjolnir.bg.grid"
-version = "0.1-2"
+version = "0.1-3"
 
 -- General metadata:
 


### PR DESCRIPTION
I just tried to add a hotkey to call `grid.adjustheight(x)` into my configuration and noticed that it didn't work. I reinstalled the latest via

``` bash
luarocks install mjolnir.bg.grid
```

and then tested to make sure that worked

``` bash
luarocks show mjolnir.bg.grid

mjolnir.bg.grid 0.1-3 - Mjolnir module for moving/resizing your windows along both virtual and horizontal grids.

Mjolnir module for moving/resizing your windows along both virtual and
horizontal grids.

License:    MIT
Homepage:   https://github.com/BrianGilbert/mjolnir.bg.grid
Installed in:   /usr/local

Modules:
    mjolnir.bg.grid (/usr/local/share/lua/5.2/mjolnir/bg/grid.lua)

Depends on:
    mjolnir.fnutils
    mjolnir.application
    mjolnir.geometry
    mjolnir.alert
    mjolnir.screen
```

Looking at your repo and the git log, I _think_ you merged the commit to fix the adjustheight method and forgot to update the rockspec. This fixes that so all you have to do is push it up to Luarocks. 
